### PR TITLE
Fix scrolling bug on iOS safari

### DIFF
--- a/assets/src/sass/styles.scss
+++ b/assets/src/sass/styles.scss
@@ -74,6 +74,10 @@ a {
   width: 100%;
   height: 100%;
   overflow-x: hidden;
+
+  /* Fix iOS Safari scroll bug */
+  overflow-y: scroll; 
+  -webkit-overflow-scrolling: touch;
 }
 
 .viewport {


### PR DESCRIPTION
Hi Raivis,

On iOS Safari there is a bug when attempting to scroll down blog posts.  The scrolling is extremely slow and stops occasionally before restarting.  After searching the internet it seems like this is a known issue with iOS safari and can be fixed with the css change in this pull request.

Check your blog on an iOS device and see if you have the same issue.  If you do, then you can use this fix :)
